### PR TITLE
bodyaddon rotation level layeroffset

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -126,6 +126,8 @@ namespace AlienRace
             public List<BodyTypeOffset> bodyTypes;
             public List<CrownTypeOffset> portraitCrownTypes;
             public List<CrownTypeOffset> crownTypes;
+            // allows to set the layer offset based on rotation
+            public float layerOffset = 0f;
         }
 
         public class BodyTypeOffset

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -2370,9 +2370,11 @@
                                                                     ba.offsets.west;
 
                 Vector2 bodyOffset = (portrait ? offset?.portraitBodyTypes ?? offset?.bodyTypes : offset?.bodyTypes)?.FirstOrDefault(predicate: to => to.bodyType == pawn.story.bodyType)
-                                   ?.offset ?? Vector2.zero;
+                    ?.offset ?? Vector2.zero;
                 Vector2 crownOffset = (portrait ? offset?.portraitCrownTypes ?? offset?.crownTypes : offset?.crownTypes)?.FirstOrDefault(predicate: to => to.crownType == alienComp.crownType)
-                                    ?.offset ?? Vector2.zero;
+                    ?.offset ?? Vector2.zero;
+                
+                float crownLayerOffset = offset.layerOffset;
 
                 //Defaults for tails 
                 //south 0.42f, -0.3f, -0.22f
@@ -2381,13 +2383,13 @@
 
                 float moffsetX = 0.42f;
                 float moffsetZ = -0.22f;
-                float moffsetY = ba.inFrontOfBody ? 0.3f + ba.layerOffset : -0.3f - ba.layerOffset;
+                float moffsetY = (ba.inFrontOfBody ? 0.3f + ba.layerOffset : -0.3f - ba.layerOffset) + crownLayerOffset;
                 float num      = ba.angle;
 
                 if (rotation == Rot4.North)
                 {
                     moffsetX = 0f;
-                    moffsetY = !ba.inFrontOfBody ? -0.3f - ba.layerOffset : 0.3f + ba.layerOffset;
+                    moffsetY = (!ba.inFrontOfBody ? -0.3f - ba.layerOffset : 0.3f + ba.layerOffset) + crownLayerOffset;
                     moffsetZ = -0.55f;
                     num      = 0;
                 }


### PR DESCRIPTION
Usage:

```
          <bodyAddons>
            <li>
              <path>Path/To/Addon</path>
              <layerOffset>0</layerOffset>
              <offsets>
                <south>
                  <crownTypes>
                    <Average_Normal>(-.42,.68)</Average_Normal>
                  </crownTypes>
              <!--  front of body -->
                    <layerOffset>-0.01</layerOffset>
                </south>
                <north>
                  <crownTypes>
                    <Average_Normal>(0,.91)</Average_Normal>
                  </crownTypes>
              <!--  rearof body -->
                  <layerOffset>-0.31</layerOffset>
                </north>
                <east>
                  <bodyTypes>
                    <Male>(.1,0)</Male>
                    <Female>(0,0)</Female>
                    <Fat>(0,0)</Fat>
                    <Thin>(0,0)</Thin>
                    <Hulk>(0,0)</Hulk>
                  </bodyTypes>
                  <crownTypes>
                    <Average_Normal>(-.5,.6)</Average_Normal>
                  </crownTypes>
              <!--  front of body -->
                  <layerOffset>-0.01</layerOffset>
                </east>
                <west>
                  <bodyTypes>
                    <Male>(.1,0)</Male>
                    <Female>(0,0)</Female>
                    <Fat>(0,0)</Fat>
                    <Thin>(0,0)</Thin>
                    <Hulk>(0,0)</Hulk>
                  </bodyTypes>
                  <crownTypes>
                    <Average_Normal>(-.5,.6)</Average_Normal>
                  </crownTypes>
              <!--  rear of body -->
              <layerOffset>-0.31</layerOffset>
                </west>
              </offsets>
            </li>
```