### PR TITLE
Added rotational y-depth inversion.

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -19,6 +19,7 @@ namespace AlienRace
             [Obsolete("Replaced by color channels")]
             public bool useSkinColor = true;
             public BodyAddonOffsets offsets;
+            public RotationalLayerInvert rotLayerInvert;
             public bool linkVariantIndexWithPrevious = false;
             public float angle = 0f;
             public bool inFrontOfBody = false;
@@ -117,6 +118,14 @@ namespace AlienRace
                 this.backstory = xmlRoot.Name;
                 this.path = xmlRoot.FirstChild.Value;
             }
+        }
+
+        public class RotationalLayerInvert
+        {
+            public bool south = false;
+            public bool north = false;
+            public bool east = false;
+            public bool west = false;
         }
 
         public class BodyAddonOffsets

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -2318,6 +2318,11 @@
                                                                     ba.offsets.east : 
                                                                     ba.offsets.west;
 
+                bool rotInvert = rotation == Rot4.South ? ba.rotLayerInvert.south :
+                                 rotation == Rot4.North ? ba.rotLayerInvert.north :
+                                 rotation == Rot4.East ? ba.rotLayerInvert.east :
+                                 ba.rotLayerInvert.west;
+
                 Vector2 bodyOffset = (portrait ? offset?.portraitBodyTypes ?? offset?.bodyTypes : offset?.bodyTypes)?.FirstOrDefault(predicate: to => to.bodyType == pawn.story.bodyType)
                                    ?.offset ?? Vector2.zero;
                 Vector2 crownOffset = (portrait ? offset?.portraitCrownTypes ?? offset?.crownTypes : offset?.crownTypes)?.FirstOrDefault(predicate: to => to.crownType == alienComp.crownType)
@@ -2330,7 +2335,7 @@
 
                 float moffsetX = 0.42f;
                 float moffsetZ = -0.22f;
-                float moffsetY = ba.inFrontOfBody ? 0.3f + ba.layerOffset : -0.3f - ba.layerOffset;
+                float moffsetY = ba.inFrontOfBody != rotInvert ? 0.3f + ba.layerOffset : -0.3f - ba.layerOffset; // Using != for XOR.
                 float num      = ba.angle;
 
                 if (rotation == Rot4.North)


### PR DESCRIPTION
-Adds in a new field that allows a user to specify what rotations (N/S/E/W) should be inverted.
-Does not modify existing methods of doing so (so north still defaults to !inFrontOfBody)
-Use case: two bodyAddons for left/right ears or arms that may be partially visible behind a pawns head or body, but allow for asymmetry.  For example, a pawn has two bodyAddons that add cat ears, but their right ear gets shot off.  The remaining one needs to be in front of the body when facing east, but behind the body when facing west.