### PR TITLE
Changed logging in AlienPartGenerator

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.cs
@@ -7,6 +7,8 @@ using Verse;
 
 namespace AlienRace
 {
+    using System.Text;
+
     public partial class AlienPartGenerator
     {
         public List<string> aliencrowntypes = new List<string> { "Average_Normal" };
@@ -82,11 +84,13 @@ namespace AlienRace
 
             this.bodyAddons.Do(action: ba =>
             {
+                StringBuilder logBuilder = new StringBuilder();
+
                 if (ba.variantCount == 0)
                 {
                     while (ContentFinder<Texture2D>.Get(itemPath: ba.path + (ba.variantCount == 0 ? "" : ba.variantCount.ToString()) + "_north", reportFailure: false) != null)
                         ba.variantCount++;
-                    Log.Message(text: "Variants found for " + ba.path + ": " + ba.variantCount.ToString());
+                    logBuilder.AppendLine("Variants found for " + ba.path + ": " + ba.variantCount);
                     if (ba.hediffGraphics != null)
                         foreach (BodyAddonHediffGraphic bahg in ba.hediffGraphics)
                         {
@@ -94,7 +98,7 @@ namespace AlienRace
                             {
                                 while (ContentFinder<Texture2D>.Get(itemPath: bahg.path + (bahg.variantCount == 0 ? "" : bahg.variantCount.ToString()) + "_north", reportFailure: false) != null)
                                     bahg.variantCount++;
-                                Log.Message(text: "Variants found for " + bahg.path + ": " + bahg.variantCount.ToString());
+                                logBuilder.AppendLine("Variants found for " + bahg.path + ": " + bahg.variantCount);
                             }
                         }
                     if (ba.backstoryGraphics != null)
@@ -104,10 +108,13 @@ namespace AlienRace
                             {
                                 while (ContentFinder<Texture2D>.Get(itemPath: babg.path + (babg.variantCount == 0 ? "" : babg.variantCount.ToString()) + "_north", reportFailure: false) != null)
                                     babg.variantCount++;
-                                Log.Message(text: "Variants found for " + babg.path + ": " + babg.variantCount.ToString());
+                                logBuilder.AppendLine("Variants found for " + babg.path + ": " + babg.variantCount);
                             }
                         }
                 }
+
+                if (logBuilder.Length > 0)
+                    Log.Message(logBuilder.ToString()); 
             });
         }
 

--- a/Source/AlienRace/AlienRace/AlienPartGenerator.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.cs
@@ -82,16 +82,18 @@ namespace AlienRace
                 AddMeshSet(drawSize: graphicsPath.customPortraitDrawSize, headDrawSize: graphicsPath.customPortraitHeadDrawSize);
             }
 
+            StringBuilder logBuilder = new StringBuilder();
             this.bodyAddons.Do(action: ba =>
             {
-                StringBuilder logBuilder = new StringBuilder();
-
                 if (ba.variantCount == 0)
                 {
+                    logBuilder.AppendLine($"loading variants for {ba.path}");
+
                     while (ContentFinder<Texture2D>.Get(itemPath: ba.path + (ba.variantCount == 0 ? "" : ba.variantCount.ToString()) + "_north", reportFailure: false) != null)
                         ba.variantCount++;
                     logBuilder.AppendLine("Variants found for " + ba.path + ": " + ba.variantCount);
                     if (ba.hediffGraphics != null)
+                    {
                         foreach (BodyAddonHediffGraphic bahg in ba.hediffGraphics)
                         {
                             if (bahg.variantCount == 0)
@@ -99,9 +101,15 @@ namespace AlienRace
                                 while (ContentFinder<Texture2D>.Get(itemPath: bahg.path + (bahg.variantCount == 0 ? "" : bahg.variantCount.ToString()) + "_north", reportFailure: false) != null)
                                     bahg.variantCount++;
                                 logBuilder.AppendLine("Variants found for " + bahg.path + ": " + bahg.variantCount);
+                                if (bahg.variantCount == 0) //would there ever be a reason for a hediff graphic entry to have no entries but still set? 
+                                {
+                                    Log.Warning($"no hediff graphics found for hediff {ba.path}:{bahg.hediff} in {this.alienProps.defName}");
+                                }
                             }
                         }
+                    }
                     if (ba.backstoryGraphics != null)
+                    {
                         foreach (BodyAddonBackstoryGraphic babg in ba.backstoryGraphics)
                         {
                             if (babg.variantCount == 0)
@@ -109,13 +117,20 @@ namespace AlienRace
                                 while (ContentFinder<Texture2D>.Get(itemPath: babg.path + (babg.variantCount == 0 ? "" : babg.variantCount.ToString()) + "_north", reportFailure: false) != null)
                                     babg.variantCount++;
                                 logBuilder.AppendLine("Variants found for " + babg.path + ": " + babg.variantCount);
+                                if (babg.variantCount == 0) //would there ever be a reason for background graphics to have no entries but still set? 
+                                {
+                                    Log.Warning($"no backstory graphics found for backstory {ba.path}:{babg.backstory} in {this.alienProps.defName}");
+                                }
                             }
                         }
+
+                    }
                 }
 
-                if (logBuilder.Length > 0)
-                    Log.Message(logBuilder.ToString()); 
+                
             });
+            if (logBuilder.Length > 0)
+                 Log.Message($"loaded body addon variants for {alienProps.defName}\n{logBuilder}"); 
         }
 
         public class ColorChannelGenerator


### PR DESCRIPTION
## Proposed Changes

  - Group messages from AlienPartGenerator’s GenerateMeshsAndMeshPools function from the same race into a single log message to reduce the number of log entries at startup while still presenting information about loaded part graphics 
  - Display a warning if a hediff or backstory graphic path is set but no variants can be found 
