### PR TITLE
Make bodyTypeRequirement List-type

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -44,7 +44,7 @@ namespace AlienRace
             public List<string> hiddenUnderApparelTag = new List<string>();
 
             public string backstoryRequirement;
-            public string bodyTypeRequirement;
+            public List<string> bodyTypeRequirement;
 
             private ShaderTypeDef shaderType;
 
@@ -64,7 +64,7 @@ namespace AlienRace
                     (this.bodyPart.NullOrEmpty() || 
                      (pawn.health.hediffSet.GetNotMissingParts().Any(predicate: bpr => bpr.untranslatedCustomLabel == this.bodyPart || bpr.def.defName == this.bodyPart)) || 
                      (this.hediffGraphics?.Any(bahg => bahg.hediff == HediffDefOf.MissingBodyPart) ?? false)) &&
-               (pawn.gender == Gender.Female ? this.drawForFemale : this.drawForMale) && (this.bodyTypeRequirement.NullOrEmpty() || pawn.story.bodyType.ToString() == this.bodyTypeRequirement);
+               (pawn.gender == Gender.Female ? this.drawForFemale : this.drawForMale) && (this.bodyTypeRequirement.NullOrEmpty() || this.bodyTypeRequirement.Any(predicate: bt => bt == pawn.story.bodyType.ToString()));
 
             public virtual Graphic GetPath(Pawn pawn, ref int sharedIndex, int? savedIndex = new int?())
             {


### PR DESCRIPTION
I'd originally submitted bodyTypeRequirement with single-bodytype requirements in mind. However, I realise that limits the check's usefulness.

This change allows a bodyaddon to be shown on multiple specific bodytypes, broadening usability - an example use-case would be to include specific parts only on lithe bodytypes (female AND thin) without them spawning on bulkier frames.

I realise this change will require a slight xml tweak to listed entries for any mods using the check (on the off-chance any exist) so please let me know if I need to include support for listless singular entries.