### PR TITLE
Update HarmonyPatches.cs

### DIFF
--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -776,7 +776,7 @@
             foreach (ThingStuffPair pair in CachedData.allWeaponPairs().ListFullCopy())
             {
                 ThingDef equipment = pair.thing;
-                if (!RaceRestrictionSettings.CanEquip(equipment, pawn.def))
+                if (equipment && !RaceRestrictionSettings.CanEquip(equipment, pawn.def))
                     weaponList.Add(pair);
             }
 


### PR DESCRIPTION
Exception ticking Hive57470 (at (96, 0, 177)): System.ArgumentNullException: Value cannot be null.
Parameter name: key
  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x00008] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryGetValue (TKey key, TValue& value) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at AlienRace.RaceRestrictionSettings.CanEquip (Verse.ThingDef weapon, Verse.ThingDef race) [0x00000] in <436b5222a2bf4af098bd7afe6d99281e>:0 
  at AlienRace.HarmonyPatches.TryGenerateWeaponForPrefix (Verse.Pawn pawn) [0x0003f] in <436b5222a2bf4af098bd7afe6d99281e>:0 