### PR TITLE
Restrict humans to use only actual human bodytypes

### DIFF
--- a/1.2/Patches/HumansAreAliensToo.xml
+++ b/1.2/Patches/HumansAreAliensToo.xml
@@ -26,6 +26,13 @@
                                     <li>Narrow_Pointy</li>
                                     <li>Narrow_Wide</li>
                                 </aliencrowntypes>
+								<alienbodytypes>
+									<li>Male</li>
+									<li>Female</li>
+									<li>Thin</li>
+									<li>Hulk</li>
+									<li>Fat</li>
+								</alienbodytypes>
                                 <colorChannels>
                                     <li>
                                         <name>skin</name>


### PR DESCRIPTION
This prevents humans from accidentally borrowing custom non-human bodytypes from third-party alien race mods, and causing graphical/log errors.