### PR TITLE
Fix for NRE

### DIFF
--- a/Source/AlienRace/AlienRace/Utilities.cs
+++ b/Source/AlienRace/AlienRace/Utilities.cs
@@ -40,7 +40,9 @@
     {
         public static bool DifferentRace(ThingDef one, ThingDef two)
         {
-            return one != two                                                                                                && one.race.Humanlike && two.race.Humanlike &&
+            return one != two && 
+                   one != null && one.race != null && one.race.Humanlike &&
+                   two != null && two.race != null && two.race.Humanlike &&
                    !(one is ThingDef_AlienRace oneAr && oneAr.alienRace.generalSettings.notXenophobistTowards.Contains(two)) &&
                    !(two is ThingDef_AlienRace twoAr && twoAr.alienRace.generalSettings.immuneToXenophobia);
         }


### PR DESCRIPTION
Started receiving following error:
`
JobDriver threw exception in initAction for pawn Snan driver=JobDriver_Ingest (toilIndex=9) driver.job=(Ingest (Job_1317760) A=Thing_Pemmican391728)
System.NullReferenceException: Object reference not set to an instance of an object
  at AlienRace.Utilities.DifferentRace (Verse.ThingDef one, Verse.ThingDef two) [0x00011] in <e985ce2f5d5441eda40de72a2bb2987d>:0 
  at (wrapper dynamic-method) AlienRace.HarmonyPatches.AlienRace.HarmonyPatches.IngestedPrefix_Patch0(Verse.Pawn,Verse.Thing)
  at (wrapper dynamic-method) Verse.Thing.Verse.Thing.Ingested_Patch3(Verse.Thing,Verse.Pawn,single)
  at RimWorld.Toils_Ingest+<>c__DisplayClass12_0.<FinalizeIngest>b__0 () [0x00182] in <cdbd0ed5089a418da09b9a259f9dbd8f>:0 
  at Verse.AI.JobDriver.TryActuallyStartNextToil () [0x001de] in <cdbd0ed5089a418da09b9a259f9dbd8f>:0 
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch4 (string)
Verse.AI.JobUtility:TryStartErrorRecoverJob (Verse.Pawn,string,System.Exception,Verse.AI.JobDriver)
Verse.AI.JobDriver:TryActuallyStartNextToil ()
Verse.AI.JobDriver:ReadyForNextToil ()
(wrapper dynamic-method) Verse.AI.JobDriver:Verse.AI.JobDriver.DriverTick_Patch0 (Verse.AI.JobDriver)
(wrapper dynamic-method) Verse.AI.Pawn_JobTracker:Verse.AI.Pawn_JobTracker.JobTrackerTick_Patch0 (Verse.AI.Pawn_JobTracker)
(wrapper dynamic-method) Verse.Pawn:Verse.Pawn.Tick_Patch3 (Verse.Pawn)
Verse.TickList:Tick ()
(wrapper dynamic-method) Verse.TickManager:Verse.TickManager.DoSingleTick_Patch1 (Verse.TickManager)
Verse.TickManager:TickManagerUpdate ()
(wrapper dynamic-method) Verse.Game:Verse.Game.UpdatePlay_Patch1 (Verse.Game)
Verse.Root_Play:Update ()
`

Those line fixed this issue.

HAR mod:
Kijin 2.0
O21 ForgottenRealms
Warhammer skaven
Warhammer Gor

Issue happend on stable steam version of HAR framework.