### PR TITLE
Rewrite Hairstyle selection - adding ban function & fixing gender check issues

### DIFF
--- a/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
+++ b/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
@@ -225,7 +225,9 @@
     public class StyleSettings
     {
         public bool          hasStyle = true;
+        public bool          checkGender = false;
         public List<string>  styleTags;
+        public List<string>  bannedTags;
         public List<string>  styleTagsOverride;
         public ShaderTypeDef shader;
     }


### PR DESCRIPTION
Writes both the Pre- and Post-fixes for `WantsToUseStyle` method:
- Instead of running the same logic once, prefix uses the fact Postfix is always run and skips the original code is no style is used
- Most of the old logic has been moved to its own method: `IsValidStyleItem`

It includes one bugfix:
- Fixed non-gendered/single-gender races being unable to use all hairstyles available to them, being restricted to `Any`, `MaleUsually`, or `FemaleUsually`-gendered hairstyles. With strong confidence that this bug existed and fixed.

Also adds two more features:
- Ability to ban specific styletags (e.g. `HairShort` or `HairLong` that get included in many styletag sets), defined the same way as `<styleTags>...</styleTags>` but `<bannedTags>...</bannedTags>`
- `checkGender` to use the legacy gender-discrimination for styletags, `false` by default