### PR TITLE
Multi-stage overrides and fallbacks for apparel textures

### DIFF
--- a/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicUtility.cs
+++ b/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicUtility.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System;
+using UnityEngine;
+using Verse;
+using RimWorld;
+
+namespace AlienRace.ApparelGraphics
+{
+    public static class ApparelGraphicUtility
+    {
+        public static Dictionary<(ThingDef, ThingDef_AlienRace, BodyTypeDef), Graphic> apparelCache = new();
+
+        public static Graphic GetGraphic(string path, Shader shader, Vector2 drawSize, Color color, Apparel apparel, BodyTypeDef bodyType)
+        {
+            Pawn wearer = apparel.Wearer;
+            if (wearer != null && wearer.def is ThingDef_AlienRace alienRace)
+            {
+                if (apparelCache.TryGetValue((apparel.def, alienRace, bodyType), out Graphic cachedGraphic)) {
+                    return cachedGraphic;
+                }
+
+                string overridePath;
+                ApparelGraphicsOverrides overrides = alienRace.alienRace.graphicPaths.apparel;
+
+                // Blanket prefixes take precedence over vanilla path
+                if (!overrides.pathPrefix.NullOrEmpty() && ValidTexturesExist(overridePath = overrides.pathPrefix + path))
+                {
+                    return CacheNewGraphic(overridePath);
+                }
+
+                // If no prefix exists or if the prefix failed to find textures, try the regular textures
+                if (ValidTexturesExist(path))
+                {
+                    return CacheNewGraphic(path);
+                }
+                // If regular textures cannot be found, attempt to find a valid fallback
+                else if ((overridePath = overrides.GetOverridePath(apparel)) != null)
+                {
+                    if (bodyType != null) overridePath += "_" + bodyType.defName;
+                    return CacheNewGraphic(overridePath);
+                }
+                // If no specific overrides exist, attempt to use a fallback body type
+                else if (bodyType != null && path.EndsWith(overridePath = "_" + bodyType.defName) && overrides.TryGetBodyTypeFallback(wearer, out BodyTypeDef overrideBodyType))
+                {
+                    overridePath = ReplaceBodyType(path, overridePath, overrideBodyType);
+                    return CacheNewGraphic(overridePath);
+                }
+
+                // If all else fails, fall back to vanilla behavior
+                return CacheNewGraphic(path);
+            }
+
+            // Non-HAR races can sometimes wear apparel, such as via Animal Gear
+            return GraphicDatabase.Get<Graphic_Multi>(path, shader, drawSize, color);
+
+            Graphic CacheNewGraphic(string path)
+            {
+                Graphic graphic = GraphicDatabase.Get<Graphic_Multi>(path, shader, drawSize, color);
+                apparelCache.Add((apparel.def, alienRace, bodyType), graphic);
+                return graphic;
+            }
+        }
+
+        public static bool ValidTexturesExist(string path)
+        {
+            Texture2D southTexture = ContentFinder<Texture2D>.Get(path + Graphic_Multi.SouthSuffix, reportFailure: false);
+            if (southTexture == null)
+            {
+                return ContentFinder<Texture2D>.Get(path, reportFailure: false) != null;
+            }
+            return true;
+        }
+
+        public static string ReplaceBodyType(string path, string oldToken, BodyTypeDef newBodyType)
+        {
+            int index = path.LastIndexOf(oldToken);
+            return path.Remove(index) + "_" + newBodyType.defName;
+        }
+    }
+}

--- a/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicUtility.cs
+++ b/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicUtility.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using System;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using RimWorld;
@@ -27,6 +21,12 @@ namespace AlienRace.ApparelGraphics
                 string overridePath;
                 ApparelGraphicsOverrides overrides = alienRace.alienRace.graphicPaths.apparel;
 
+                // Check first for specific Def overrides
+                if ((overridePath = overrides.GetOverridePath(apparel)) != null)
+                {
+                    if (bodyType != null) overridePath += "_" + bodyType.defName;
+                    return CacheNewGraphic(overridePath);
+                }
                 // Blanket prefixes take precedence over vanilla path
                 if (!overrides.pathPrefix.NullOrEmpty() && ValidTexturesExist(overridePath = overrides.pathPrefix + path))
                 {
@@ -38,14 +38,15 @@ namespace AlienRace.ApparelGraphics
                 {
                     return CacheNewGraphic(path);
                 }
+
                 // If regular textures cannot be found, attempt to find a valid fallback
-                else if ((overridePath = overrides.GetOverridePath(apparel)) != null)
+                if ((overridePath = overrides.GetFallbackPath(apparel)) != null)
                 {
                     if (bodyType != null) overridePath += "_" + bodyType.defName;
                     return CacheNewGraphic(overridePath);
                 }
-                // If no specific overrides exist, attempt to use a fallback body type
-                else if (bodyType != null && path.EndsWith(overridePath = "_" + bodyType.defName) && overrides.TryGetBodyTypeFallback(wearer, out BodyTypeDef overrideBodyType))
+                // If no specific fallbacks exist, attempt to use a fallback body type
+                if (bodyType != null && path.EndsWith(overridePath = "_" + bodyType.defName) && overrides.TryGetBodyTypeFallback(wearer, out BodyTypeDef overrideBodyType))
                 {
                     overridePath = ReplaceBodyType(path, overridePath, overrideBodyType);
                     return CacheNewGraphic(overridePath);

--- a/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
+++ b/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 using RimWorld;
 using Verse;
@@ -29,6 +25,12 @@ namespace AlienRace.ApparelGraphics
                     return overridePath;
                 }
             }
+            return null;
+        }
+
+        public string GetFallbackPath(Apparel apparel)
+        {
+            if (apparel == null || apparel.def == null) return null;
             if (!fallbacks.NullOrEmpty())
             {
                 foreach(ApparelFallbackOption option in fallbacks)

--- a/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
+++ b/Source/AlienRace/AlienRace/ApparelGraphics/ApparelGraphicsOverrides.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+using RimWorld;
+using Verse;
+
+namespace AlienRace.ApparelGraphics
+{
+    public class ApparelGraphicsOverrides
+    {
+        public string pathPrefix = null;
+        public Dictionary<ThingDef, string> individualFallbackPaths;
+        public List<ApparelFallbackOption> fallbacks;
+        public BodyTypeDef bodyTypeFallback = null;
+        public BodyTypeDef femaleBodyTypeFallback = null;
+
+        public string GetOverridePath(Apparel apparel)
+        {
+            if (apparel == null || apparel.def == null) return null;
+
+            if (!individualFallbackPaths.NullOrEmpty())
+            {
+                if (individualFallbackPaths.TryGetValue(apparel.def, out string overridePath))
+                {
+                    return overridePath;
+                }
+            }
+            if (!fallbacks.NullOrEmpty())
+            {
+                foreach(ApparelFallbackOption option in fallbacks)
+                {
+                    if (option.IsSuitableFallBackFor(apparel.def))
+                    {
+                        return option.wornGraphicPath;
+                    }
+                }
+            }
+            return null;
+        }
+
+        public bool TryGetBodyTypeFallback(Pawn pawn, out BodyTypeDef def)
+        {
+            def = null;
+            if (pawn == null) return false;
+            if (pawn.gender == Gender.Female && femaleBodyTypeFallback != null)
+            {
+                def = femaleBodyTypeFallback;
+                return true;
+            }
+            def = bodyTypeFallback;
+            return def != null;
+        }
+    }
+
+    public class ApparelFallbackOption
+    {
+        public string wornGraphicPath = "";
+        public List<string> wornGraphicPaths;
+
+        public List<string> apparelTags;
+        public List<BodyPartGroupDef> bodyPartGroups = new List<BodyPartGroupDef>();
+        public List<ApparelLayerDef> layers = new List<ApparelLayerDef>();
+
+        public string GetGraphicPath(ThingDef apparelDef)
+        {
+            if (!wornGraphicPaths.NullOrEmpty())
+            {
+                return wornGraphicPaths[apparelDef.GetHashCode() % wornGraphicPaths.Count];
+            }
+            return wornGraphicPath;
+        }
+        public bool IsSuitableFallBackFor(ThingDef apparelDef)
+        {
+            if (apparelDef == null || apparelDef.apparel == null) return false;
+            ApparelProperties props = apparelDef.apparel;
+
+            if (!apparelTags.NullOrEmpty() && (props.tags.NullOrEmpty() || !props.tags.Intersect(apparelTags).Any())) return false;
+            if (!bodyPartGroups.NullOrEmpty() && (props.bodyPartGroups.NullOrEmpty() || !props.bodyPartGroups.Intersect(bodyPartGroups).Any())) return false;
+            if (!layers.NullOrEmpty() && (props.layers.NullOrEmpty() || !props.layers.Intersect(layers).Any())) return false;
+
+            return true;
+        }
+    }
+}

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -280,6 +280,8 @@ namespace AlienRace
 
             harmony.Patch(AccessTools.Method(typeof(Pawn_GeneTracker), nameof(Pawn_GeneTracker.AddGene), new[] { typeof(Gene), typeof(bool) }), new HarmonyMethod(patchType, nameof(AddGenePrefix)));
 
+            harmony.Patch(AccessTools.Method(typeof(ApparelGraphicRecordGetter), nameof(ApparelGraphicRecordGetter.TryGetGraphicApparel)), transpiler: new HarmonyMethod(patchType, nameof(TryGetGraphicApparelTranspiler)));
+
             foreach (ThingDef_AlienRace ar in DefDatabase<ThingDef_AlienRace>.AllDefsListForReading)
             {
                 foreach (ThoughtDef thoughtDef in ar.alienRace.thoughtSettings.restrictedThoughts)
@@ -3317,6 +3319,31 @@ namespace AlienRace
         public static void DrawAddonsFinalHook(Pawn pawn, AlienPartGenerator.BodyAddon addon, Rot4 rot, ref Graphic graphic, ref Vector3 offsetVector, ref float angle, ref Material mat)
         {
 
+        }
+
+        public static IEnumerable<CodeInstruction> TryGetGraphicApparelTranspiler(IEnumerable<CodeInstruction> codeInstructions)
+        {
+            MethodInfo originalMethod = AccessTools.Method(
+                typeof(GraphicDatabase),
+                "Get",
+                new Type[] { typeof(string), typeof(Shader), typeof(Vector2), typeof(Color) },
+                new Type[] { typeof(Graphic_Multi) }
+            );
+            MethodInfo newMethod = AccessTools.Method(typeof(ApparelGraphics.ApparelGraphicUtility), nameof(ApparelGraphics.ApparelGraphicUtility.GetGraphic));
+            foreach(CodeInstruction instruction in codeInstructions)
+            {
+                if (instruction.Calls(originalMethod))
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg_0); // apparel
+                    yield return new CodeInstruction(OpCodes.Ldarg_1); // bodyType
+                    yield return new CodeInstruction(OpCodes.Call, newMethod);
+
+                }
+                else
+                {
+                    yield return instruction;
+                }
+            }
         }
     }
 }

--- a/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
+++ b/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
@@ -239,6 +239,8 @@
         public AlienPartGenerator.ExtendedGraphicTop skull    = new() { path = "Things/Pawn/Humanlike/Heads/None_Average_Skull" };
         public AlienPartGenerator.ExtendedGraphicTop stump    = new() { path = "Things/Pawn/Humanlike/Heads/None_Average_Stump" };
 
+        public ApparelGraphics.ApparelGraphicsOverrides apparel = new();
+
         public ShaderTypeDef   skinShader;
         public Color           skinColor = new Color(1f, 0f, 0f, 1f);
 
@@ -584,8 +586,8 @@
                 result = (raceRestriction?.whiteGeneList.Contains(gene) ?? false) ||
                          (gene.exclusionTags?.Any(t => raceRestriction?.whiteGeneTags.Contains(t) ?? false) ?? false);
 
-            return result && 
-                   !(raceRestriction?.blackGeneList.Contains(gene) ?? false) && 
+            return result &&
+                   !(raceRestriction?.blackGeneList.Contains(gene) ?? false) &&
                    !(gene.exclusionTags?.Any(t => raceRestriction?.blackGeneTags.Contains(t) ?? false) ?? false) &&
                    !(raceRestriction?.blackEndoCategories.Contains(gene.endogeneCategory) ?? false);
         }


### PR DESCRIPTION
Implements racial override and fallback textures for races:

1. If there's a specific path override for a specific ThingDef (not shown in example below), that takes precedence.
2. If a path prefix is provided for a race, then all apparel runs through that first. If matching textures are found under the prefixed path, then those are used.
3. The vanilla path with the wearer's specific bodytype is checked next. If those textures are found, then everything works as normal.
4. If the race has <fallbacks> set, it runs down the list in order and sees if any of them match the current apparel piece. This will check against body part groups, layers, and/or apparel tags. This can be used to set a transparent texture to make apparel invisible.
5. If the race has a bodytype fallback (either <bodyTypeFallback> or <femaleBodyTypeFallback>, then it will attempt to substitute the fallback body type in the vanilla-generated texture path and see if that yields any usable textures.
6. If all else fails, it allows normal vanilla behavior to occur.

An example of the XML applied in `<graphicPaths>`:

```xml
<graphicPaths>
  <apparel>
    <pathPrefix>ARimReborn/Lalafell/</pathPrefix>
    <fallbacks>
      <li>
        <wornGraphicPath>Things/Pawn/Humanlike/Apparel/Jacket/Jacket</wornGraphicPath>
        <layers>
          <li>Shell</li>
        </layers>
      </li>
    </fallbacks>
    <bodyTypeFallback>Thin</bodyTypeFallback>
  </apparel>
</graphicPaths>
```
A test using the above XML:
![image](https://user-images.githubusercontent.com/1125647/200226267-d5f39061-159f-484c-a18b-bb53e4f36ddc.png)

1. A racial override for a piece of headwear,
2. A fallback for all Shell layer apparel to a specific graphic, and
3. A bodytype fallback for all apparel lacking textures for a race's specific bodytype

