### PR TITLE
Backstory body type fix plus options for nonstandard gendered defaults

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.cs
@@ -20,6 +20,8 @@
             this.headTypes ?? CachedData.DefaultHeadTypeDefs;
 
         public List<BodyTypeDef> bodyTypes = new();
+        public BodyTypeDef defaultMaleBodyType;
+        public BodyTypeDef defaultFemaleBodyType;
 
         [Obsolete]
         public int getsGreyAt = 40;

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -3512,22 +3512,21 @@ namespace AlienRace
         }
 
         public static void GetBodyTypeForPostfix(Pawn pawn, ref BodyTypeDef __result) =>
-            __result = CheckBodyType(pawn);
+            __result = CheckBodyType(pawn, __result);
 
-        public static void GenerateBodyTypePostfix(Pawn pawn) => 
-            pawn.story.bodyType = CheckBodyType(pawn);
+        public static void GenerateBodyTypePostfix(Pawn pawn) =>
+            pawn.story.bodyType = CheckBodyType(pawn, pawn.story.bodyType);
 
-        public static BodyTypeDef CheckBodyType(Pawn pawn)
+        public static BodyTypeDef CheckBodyType(Pawn pawn, BodyTypeDef bodyType)
         {
-            BodyTypeDef bodyType = pawn.story.bodyType;
-
             if (AlienBackstoryDef.checkBodyType.Contains(pawn.story.GetBackstory(BackstorySlot.Adulthood)))
                 bodyType = DefDatabase<BodyTypeDef>.GetRandom();
 
             if (pawn.def is ThingDef_AlienRace alienProps &&
+                alienProps.alienRace.generalSettings.alienPartGenerator is AlienPartGenerator parts &&
                 !alienProps.alienRace.generalSettings.alienPartGenerator.bodyTypes.NullOrEmpty())
             {
-                List<BodyTypeDef> bodyTypeDefs = alienProps.alienRace.generalSettings.alienPartGenerator.bodyTypes.ListFullCopy();
+                List<BodyTypeDef> bodyTypeDefs = parts.bodyTypes.ListFullCopy();
 
                 if ((pawn.ageTracker.CurLifeStage.developmentalStage.Baby() || pawn.ageTracker.CurLifeStage.developmentalStage.Newborn()) && bodyTypeDefs.Contains(BodyTypeDefOf.Baby))
                 {
@@ -3542,11 +3541,19 @@ namespace AlienRace
                     bodyTypeDefs.Remove(BodyTypeDefOf.Baby);
                     bodyTypeDefs.Remove(BodyTypeDefOf.Child);
 
-                    if (pawn.gender == Gender.Male && bodyTypeDefs.Contains(BodyTypeDefOf.Female) && bodyTypeDefs.Count > 1)
-                        bodyTypeDefs.Remove(BodyTypeDefOf.Female);
+                    if (pawn.gender == Gender.Male)
+                    {
+                        BodyTypeDef femaleBodyType = parts.defaultFemaleBodyType;
+                        if (bodyTypeDefs.Contains(femaleBodyType) && bodyTypeDefs.Count > 1)
+                            bodyTypeDefs.Remove(femaleBodyType);
+                    }
 
-                    if (pawn.gender == Gender.Female && bodyTypeDefs.Contains(BodyTypeDefOf.Male) && bodyTypeDefs.Count > 1)
-                        bodyTypeDefs.Remove(BodyTypeDefOf.Male);
+                    if (pawn.gender == Gender.Female)
+                    {
+                        BodyTypeDef maleBodyType = parts.defaultMaleBodyType;
+                        if (bodyTypeDefs.Contains(maleBodyType) && bodyTypeDefs.Count > 1)
+                            bodyTypeDefs.Remove(maleBodyType);
+                    }
 
                     if (!bodyTypeDefs.Contains(bodyType))
                         bodyType = bodyTypeDefs.RandomElement();

--- a/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
+++ b/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
@@ -130,6 +130,11 @@
                 }
             }
 
+            if (this.alienRace.generalSettings.alienPartGenerator.defaultMaleBodyType == null)
+                this.alienRace.generalSettings.alienPartGenerator.defaultMaleBodyType = BodyTypeDefOf.Male;
+            if (this.alienRace.generalSettings.alienPartGenerator.defaultFemaleBodyType == null)
+                this.alienRace.generalSettings.alienPartGenerator.defaultFemaleBodyType = BodyTypeDefOf.Female;
+
             void RecursiveAttributeCheck(Type type, Traverse instance)
             {
                 if (type == typeof(ThingDef_AlienRace))


### PR DESCRIPTION
[Bug fix] Refactored GetBodyTypeForPostfix, GenerateBodyTypePostfix, and CheckBodyType to respect the vanilla-generated value in the former prefix, which is where body type specifications in backstories were checked. GetBodyTypeForPrefix was discarding the value of its __result field, which caused all backstory overrides to fail, including for humans.

[Addition] Added defaultMaleBodyType and defaultFemaleBodyType fields to <alienPartGenerator>, which are default-initialized to BodyTypeDefOf.Male and BodyTypeDefOf.Female in ThingDef_AlienRaces.ResolveReferences. This is then used by CheckBodyType to exclude gender-default body types instead of the hardcoded vanilla types.

Use case: This is desirable by races that are using entirely custom body types to specify gendered defaults without having to resort to backstory forced types, which necessarily restrict the entire pool down to only a single body type per race.