### PR TITLE
Race-specific overrides for StatPart_Age

### DIFF
--- a/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
+++ b/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
@@ -10,6 +10,7 @@
     using RimWorld.BaseGen;
     using UnityEngine;
     using Verse;
+    using System.Xml;
 
     public class ThingDef_AlienRace : ThingDef
     {
@@ -38,6 +39,9 @@
 
             if (this.alienRace.generalSettings.minAgeForAdulthood < 0)
                 this.alienRace.generalSettings.minAgeForAdulthood = (float) AccessTools.Field(typeof(PawnBioAndNameGenerator), name: "MinAgeForAdulthood").GetValue(obj: null);
+
+            foreach (StatPartAgeOverride spao in this.alienRace.generalSettings.ageStatOverrides)
+                this.alienRace.generalSettings.ageStatOverride[spao.stat] = spao.overridePart;
 
             for (int i = 0; i < this.race.lifeStageAges.Count; i++)
             {
@@ -215,6 +219,11 @@
         public ReproductionSettings reproduction = new();
 
         public List<AlienChanceEntry<GeneDef>> raceGenes = new();
+
+        internal List<StatPartAgeOverride> ageStatOverrides = new();
+
+        [Unsaved]
+        public Dictionary<StatDef, StatPart_Age> ageStatOverride = new();
     }
 
     public class ReproductionSettings
@@ -805,6 +814,18 @@
         public Vector2         customFemalePortraitDrawSize     = Vector2.zero;
         public Vector2         customFemaleHeadDrawSize         = Vector2.zero;
         public Vector2         customFemalePortraitHeadDrawSize = Vector2.zero;
+    }
+
+    public class StatPartAgeOverride
+    {
+        public StatDef stat;
+        public StatPart_Age overridePart;
+
+        public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+        {
+            DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "stat", xmlRoot.Name);
+            overridePart = DirectXmlToObject.ObjectFromXml<StatPart_Age>(xmlRoot, false);
+        }
     }
 
     public class CompatibilityInfo


### PR DESCRIPTION
Allows for races to override the curves used by StatPart_Age on a race-by-race basis. This affects the following vanilla and official DLC StatDefs:

WorkSpeedGlobal
ShootingAccuracyChildFactor
MarketValue
MeleeHitChance
AimingDelayFactor
ImmunityGainSpeed
ArrestSuccessChance

Usage would be as follows, with the human defaults shown:

```xml
<generalSettings>
  <ageStatOverrides>
    <WorkSpeedGlobal>
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(4,0.2)</li>
          <li>(12,0.8)</li>
          <li>(18,1)</li>
        </points>
      </curve>
    </WorkSpeedGlobal>
    <!-- This one requires a MayRequire because the stat itself is Biotech-specific -->
    <ShootingAccuracyChildFactor MayRequire="Ludeon.RimWorld.Biotech">
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(4,0.95)</li> 
          <li>(12,0.98)</li>
          <li>(13,1)</li>
        </points>
      </curve>
    </ShootingAccuracyChildFactor>
    <MarketValue>
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(3,0.5)</li>
          <li>(13,0.9)</li>
          <li>(18,1)</li>
        </points>
      </curve>
    </MarketValue>
    <MeleeHitChance>
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(4,0.05)</li>
          <li>(12,0.8)</li>
          <li>(13,1)</li>
        </points>
      </curve>
    </MeleeHitChance>
    <AimingDelayFactor>
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(4,1.8)</li>
          <li>(12,1.1)</li>
          <li>(13,1)</li>
        </points>
      </curve>
    </AimingDelayFactor>
    <!-- This is the only stat that doesn't use biological years by default because it's used for non-humanlike pawns -->
    <ImmunityGainSpeed>
      <curve>
        <points>
          <li>(0.65,1)</li>
          <li>(0.8,0.95)</li>
          <li>(1.0,0.9)</li>
          <li>(1.2,0.8)</li>
          <li>(1.5,0.5)</li>
        </points>
      </curve>
    </ImmunityGainSpeed>
    <ArrestSuccessChance>
      <useBiologicalYears>true</useBiologicalYears>
      <curve>
        <points>
          <li>(3, 0.05)</li>
          <li>(13, 0.8)</li>
          <li>(18, 1)</li>
        </points>
      </curve>
    </ArrestSuccessChance>
  </ageStatOverrides>
</generalSettings>
```

Screenshot shown shows a single-point override that disables age-based penalties for work speed:
![image](https://github.com/erdelf/AlienRaces/assets/1125647/d854f0fa-1746-41c8-8cf2-d64b555d1bde)
