### PR TITLE
Basic hook for adding vanilla AbilityDefs to a race

### DIFF
--- a/Source/AlienRace/AlienRace/ExtendedGraphics/AbstractExtendedGraphic.cs
+++ b/Source/AlienRace/AlienRace/ExtendedGraphics/AbstractExtendedGraphic.cs
@@ -140,10 +140,6 @@ public abstract class AbstractExtendedGraphic : IExtendedGraphic
     
     protected virtual void SetFieldFromXmlNode(Traverse field, XmlNode xmlNode)
     {
-        if (!field.FieldExists()) 
-            return;
-        field.SetValue(field.GetValueType().IsGenericType ? 
-                           DirectXmlToObject.GetObjectFromXmlMethod(field.GetValueType())(xmlNode, false) : 
-                           ParseHelper.FromString(xmlNode.InnerXml.Trim(), field.GetValueType()));
+        Utilities.SetFieldFromXmlNode(field, xmlNode);
     }
 }

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -126,7 +126,8 @@ namespace AlienRace
 
             harmony.Patch(AccessTools.Method(typeof(Pawn_AgeTracker), name: "BirthdayBiological"), new HarmonyMethod(patchType, nameof(BirthdayBiologicalPrefix)));
             harmony.Patch(AccessTools.Method(typeof(PawnGenerator), nameof(PawnGenerator.GeneratePawn), new[] { typeof(PawnGenerationRequest) }),
-                new HarmonyMethod(patchType, nameof(GeneratePawnPrefix)));
+                new HarmonyMethod(patchType, nameof(GeneratePawnPrefix)),
+                postfix: new HarmonyMethod(patchType, nameof(GeneratePawnPostfix)));
             harmony.Patch(AccessTools.Method(typeof(PawnGraphicSet), nameof(PawnGraphicSet.ResolveAllGraphics)),
                 new HarmonyMethod(patchType, nameof(ResolveAllGraphicsPrefix)));
             
@@ -3918,6 +3919,17 @@ namespace AlienRace
             }
 
             request.KindDef = kindDef;
+        }
+
+        public static void GeneratePawnPostfix(Pawn __result)
+        {
+            if (__result != null && __result.def is ThingDef_AlienRace race)
+            {
+                foreach(AbilityDef ability in race.alienRace.generalSettings.abilities)
+                {
+                    __result.abilities?.GainAbility(ability);
+                }
+            }
         }
 
         public static  Pair<WeakReference, bool>                 portraitRender;

--- a/Source/AlienRace/AlienRace/HarmonyPatches.cs
+++ b/Source/AlienRace/AlienRace/HarmonyPatches.cs
@@ -11,6 +11,7 @@ namespace AlienRace
     using RimWorld;
     using RimWorld.QuestGen;
     using UnityEngine;
+    using UnityEngine.Networking;
     using Verse;
     using Verse.AI;
     using Verse.Grammar;
@@ -3364,7 +3365,8 @@ namespace AlienRace
             if (pawn.def is ThingDef_AlienRace alienProps)
                 foreach (AlienChanceEntry<GeneDef> gene in alienProps.alienRace.generalSettings.raceGenes)
                     if (gene.Approved(pawn))
-                        pawn.genes.AddGene(gene.defName, false);
+                        foreach(GeneDef option in gene.Select())
+                            pawn.genes.AddGene(option, false);
         }
 
         public static void GenerateGenesPrefix(Pawn pawn, ref PawnGenerationRequest request)
@@ -3923,11 +3925,16 @@ namespace AlienRace
 
         public static void GeneratePawnPostfix(Pawn __result)
         {
-            if (__result != null && __result.def is ThingDef_AlienRace race)
+            if (__result != null && __result.def is ThingDef_AlienRace race && race.alienRace.generalSettings.abilities != null)
             {
-                foreach(AbilityDef ability in race.alienRace.generalSettings.abilities)
+                foreach(AlienChanceEntry<AbilityDef> entry in race.alienRace.generalSettings.abilities)
                 {
-                    __result.abilities?.GainAbility(ability);
+                    if (entry.Approved(__result)) {
+                        foreach (AbilityDef ability in entry.Select())
+                        {
+                            __result.abilities?.GainAbility(ability);
+                        }
+                    }
                 }
             }
         }

--- a/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
+++ b/Source/AlienRace/AlienRace/ThingDef_AlienRace.cs
@@ -194,6 +194,7 @@
         public IntRange               additionalTraits   = IntRange.zero;
         public AlienPartGenerator     alienPartGenerator = new();
         public List<SkillGain>        passions           = new();
+        public List<AbilityDef>       abilities          = new();
 
         public List<FactionRelationSettings> factionRelations;
         public int                           maxDamageForSocialfight = int.MaxValue;

--- a/Source/AlienRace/AlienRace/Utilities.cs
+++ b/Source/AlienRace/AlienRace/Utilities.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
+    using System.Xml;
     using AlienRace.ExtendedGraphics;
     using HarmonyLib;
     using JetBrains.Annotations;
@@ -88,6 +89,16 @@
             }
         }
 
+        public static void SetFieldFromXmlNode(Traverse field, XmlNode xmlNode)
+        {
+            if (!field.FieldExists())
+                return;
+            field.SetValue(field.GetValueType().IsGenericType ?
+                               DirectXmlToObject.GetObjectFromXmlMethod(field.GetValueType())(xmlNode, false) :
+                               ParseHelper.FromString(xmlNode.InnerXml.Trim(), field.GetValueType()));
+        }
+
+
         public static void GeneBodyAddonPatcher(this List<AlienPartGenerator.BodyAddon> universal)
         {
             List<AlienPartGenerator.BodyAddon> geneAddons  = new();
@@ -163,6 +174,7 @@
     [StaticConstructorOnStartup]
     public static class CachedData
     {
+        [StaticConstructorOnStartup]
         public static class Textures
         {
             public static readonly Texture2D AlienIconInactive = ContentFinder<Texture2D>.Get("AlienRace/UI/AlienIconInactive");


### PR DESCRIPTION
A simple, low-overhead hook for applying vanilla abilities to a race after generation.

Can be used by simply specifying one or more vanilla AbilityDef instances in a race's general settings:

```xml
<AlienRace.ThingDef_AlienRace>
  <!-- snip -->
  <alienRace>
    <!-- snip -->
    <generalSettings>
      <abilities>
        <li MayRequire="Ludeon.RimWorld.Biotech">FireSpew</li>
      </abilities>
    </generalSettings>
  </alienRace>
</AlienRace.ThingDef_AlienRace>
```

In action:
![image](https://github.com/erdelf/AlienRaces/assets/1125647/978371c1-ed26-47e8-80ac-620254deb2b7)
