### PR TITLE
#113 try fix NullReferenceException

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.cs
@@ -863,7 +863,7 @@
                 foreach ((string channel, ExposableValueTuple<Color, Color> colors) in originalComp.ColorChannels)
                     cloneComp.OverwriteColorChannel(channel, colors.first, colors.second);
 
-                cloneComp.addonVariants     = originalComp.addonVariants.ListFullCopy();
+                cloneComp.addonVariants     = originalComp.addonVariants == null ? null : originalComp.addonVariants.ListFullCopy();
                 cloneComp.addonColors       = originalComp.addonColors.Select(vt => new ExposableValueTuple<Color?, Color?>(vt.first, vt.second)).ToList();
                 cloneComp.colorChannelLinks = [];
                 foreach ((string key, ColorChannelLinkData originalData) in originalComp.ColorChannelLinks)


### PR DESCRIPTION
#113 

Prevent NullReferenceException in AlienComp.CopyAlienData when addonVariants is null

This PR fixes a crash occurring during faction trading when generating trader stock with faction leader statues. The original code failed when addonVariants was null during the cloning process in AlienComp.CopyAlienData().

But I don't know much about the project, this patch seems to solve the problem, I hope this can help you locate the problem